### PR TITLE
Region list addition to yml file for increased flexibility and compatibility

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -39,6 +39,11 @@ MaxConnections: 20
 MaxGamePeers: 0
 TickTimeBudget: 2000
 
+#Optional Override for Region List
+#RegionList:
+#    - Asia
+#    - Europe
+
 
 # Settings database
 # Requires LUXON_SERVER_ENABLE_SETTINGS_DATABASE

--- a/include/luxon/server/server_manager.hpp
+++ b/include/luxon/server/server_manager.hpp
@@ -86,6 +86,7 @@ struct HttpServerConfig {
 ///
 struct ServerManagerConfig {
     std::vector<ServerConfig> servers;
+    std::vector<std::string> region_list;
     bool enable_ipv6 = true;
     bool no_banner = false;
     unsigned max_connections = 0;
@@ -175,8 +176,14 @@ public:
     Hookpoints hookpoints;
 #endif
 
+    // For use by the handler_nameserver
+    const std::vector<std::string>& get_region_list() const { return region_list_; }
+
 private:
     SockSelector sock_selector_;
+
+    // For use by the handler_nameserver
+    std::vector<std::string> region_list_;
 
     std::shared_ptr<logger> log_;
     std::vector<ServerConfig> configs_;

--- a/src/handler_nameserver.cpp
+++ b/src/handler_nameserver.cpp
@@ -48,8 +48,13 @@ Awaitable<> NameServerHandler::HandleOperationRequest(ser::OperationRequestMessa
         case OpCodes::RpcAndMisc::GetRegions: {
             ZoneScopedN("HandleOperationRequest_GetRegions");
 
-            // Build dummy response with all regions
+            // Build dummy response with all regions unless overidden by config
             std::vector<std::string> regions = {"asia", "au", "cae", "cn", "eu", "hk", "in", "jp", "za", "sa", "kr", "tr", "uae", "us", "usw", "ussc"};
+            const std::vector<std::string>& regions_from_yml = server_manager_.get_region_list();
+
+            if( regions_from_yml.empty() == false ) {
+                regions = regions_from_yml;
+            }
 
             std::vector<std::string> addresses(regions.size());
             for (size_t i = 0; i < regions.size(); ++i)

--- a/src/server_manager.cpp
+++ b/src/server_manager.cpp
@@ -382,6 +382,25 @@ ServerManagerConfig ServerManager::parse_config(const std::string& config_conten
 
         if (key == "Servers") {
             ParseServersSection(config, section);
+        } else if (key == "RegionList") {
+            if (section.IsScalar()) {
+                config.region_list.push_back(section.As<std::string>());
+            } else if( section.IsSequence() ) {
+                for (Yaml::Iterator it = section.Begin(); it != section.End(); it.operator++(1)) {
+                    Yaml::Node& region_node = (*it).second;
+                    if (region_node.IsScalar()) {
+                       config.region_list.push_back(region_node.As<std::string>());
+                    } else {        
+                        create_logger("ConfigParser")
+                            ->warn("The 'RegionList' must be a valid scalar or valid sequence in yml. It is not, so the default value will be used.");
+                        config.region_list.clear();
+                        break;
+                    }
+                }
+            } else { 
+                create_logger("ConfigParser")
+                    ->warn("The 'RegionList' must be a valid scalar or valid sequence in yml. It is not, so the default value will be used.");
+            }
         } else if (key == "External") {
             create_logger("ConfigParser")
                 ->warn("The 'External' configuration block is deprecated and will be ignored. Please migrate to using 'proxies' within the 'Servers' block.");
@@ -442,6 +461,9 @@ ServerManager::ServerManager(ServerManagerConfig config
     if (parent_ipc_.is_open())
         config.no_banner = true;
 #endif
+
+    // Fill in the region list for the handler_nameserver
+    region_list_ = (std::move(config.region_list));
 
     if (!config.no_banner) {
         static bool banner_printed = false;


### PR DESCRIPTION
This pull request adds the RegionList key to the config.yml file. Instead of relying only on the default of:
                regions = {"asia", "au", "cae", "cn", "eu", "hk", "in", "jp", "za", "sa", "kr", "tr", "uae", "us", "usw", "ussc"};
a user can now specify the regions which are used.


YML Syntax (Under the Misc Section of config.yml):
Example 1:
RegionList:
    - Asia

Example 2:
RegionList:
    - Asia
    - Europe

Example 3:
RegionList: Asia

Example #2 has been added to the config.yml file but it is commented out.


Reasons to add this:
1.	This can be used to try to match the region names used/displayed by the client. Unknown regions from the client side may not always be responded to appropriately.
2.	It has been observed at least in one case that going down to 1 region (or at least less number of regions), can result in less issues. This can led to the initial phases of creating a game / joining a game to succeed most/all of the time. Whereas with a big list of unrecognized regions, either or both sides can fail. Secondly, this erratic behavior can make finding problems much more difficult.
3.	It has been observed in at least one case, that a smaller region list of valid names can result in a shorter time for the join/create game to initially respond back to the user. (observed around 5 seconds vs 35 seconds)
4.	This does not change the default behavior if the new key is not specified in the .yml file. So this will not break existing configurations.
